### PR TITLE
replace \vr(t) with r(t) in a scalar function

### DIFF
--- a/source/S-mv-fns-vecval-fn-deriv.ptx
+++ b/source/S-mv-fns-vecval-fn-deriv.ptx
@@ -1178,7 +1178,7 @@
 
               <li>
                 <p>
-                  <m>\vr(t) = \langle \cos(t), \sin(t), t \rangle \cdot \langle -\sin(t), \cos(t), 1 \rangle</m>
+                  <m>r(t) = \langle \cos(t), \sin(t), t \rangle \cdot \langle -\sin(t), \cos(t), 1 \rangle</m>
                 </p>
               </li>
 

--- a/source/S-mv-fns-vecval-fn-deriv.ptx
+++ b/source/S-mv-fns-vecval-fn-deriv.ptx
@@ -1178,7 +1178,7 @@
 
               <li>
                 <p>
-                  <m>r(t) = \langle \cos(t), \sin(t), t \rangle \cdot \langle -\sin(t), \cos(t), 1 \rangle</m>
+                  <m>f(t) = \langle \cos(t), \sin(t), t \rangle \cdot \langle -\sin(t), \cos(t), 1 \rangle</m>
                 </p>
               </li>
 


### PR DESCRIPTION
The function in part (c) of [this activity](https://activecalculus.org/multi/S-9-7-Vector-Valued-Functions-Derivatives.html#Ez_9_7_1) is in fact a scalar function (it's the result of a dot product). I am thus renaming it r(t) instead of \vr(t) so it looks like a scalar function.